### PR TITLE
TA-19 refactor: correct styles Loader and ErrorMessage

### DIFF
--- a/src/components/ErrorMessage/ErrorMessage.module.scss
+++ b/src/components/ErrorMessage/ErrorMessage.module.scss
@@ -1,6 +1,9 @@
 .errorMessage {
+  margin: 0 auto;
   text-align: center;
-  max-width: 200px;
+  max-width: 350px;
+  padding: 20px;
+
   svg {
     width: 50px;
     height: 50px;
@@ -10,5 +13,3 @@
     text-align: center;
   }
 }
-
-

--- a/src/components/Loader/Loader.scss
+++ b/src/components/Loader/Loader.scss
@@ -1,9 +1,12 @@
-.Loader {
+.loader {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100px;
+  height: 100px;
+
   .cssload-loader {
-    position: relative;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
     width: 100px;
     height: 100px;
     margin: 0;

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import './Loader.scss';
 
 export const Loader: FC = () => (
-  <div className="Loader">
+  <div className="loader">
     <div className="cssload-loader">
       <div className="cssload-inner cssload-one" />
       <div className="cssload-inner cssload-two" />


### PR DESCRIPTION
Closes: #26 
Откорректировал стили лоадера и сообщения об ошибке. 
Лоадер будет центрироваться абсолютно по центру контейнера. Для этого контейнеру нужно выставлять **`position: relative`**

Сообщение об ошибке отцентрировано по горизонтали. По вертикали будет на самом верху.