### PR TITLE
Ta 33 rating and DB

### DIFF
--- a/src/modules/CountryPage/components/CountryPageView/components/PhotoGallery/PhotoGallery.tsx
+++ b/src/modules/CountryPage/components/CountryPageView/components/PhotoGallery/PhotoGallery.tsx
@@ -21,7 +21,6 @@ import { Button } from '@material-ui/core';
 import { useSelector } from 'react-redux';
 import { database } from 'services';
 import classes from './PhotoGallery.module.scss';
-import { log } from 'util';
 
 type PhotoGalleryProps = {
   sliderData: SliderDataType[];
@@ -142,7 +141,7 @@ export const PhotoGallery: FC<PhotoGalleryProps> = ({ sliderData, lang }) => {
 
   const setRating = (attrId: string, rating: number) => {
     database
-      .setRaiting(countryId, attrId, userId, rating)
+      .setRating(countryId, attrId, userId, rating)
       .then((data: [UserInfo, CountryType]) => {
         // в ответе получаем данные пользователя и данные текущей страны.
         // Возможно это излишняя инфа и я попробую ее сократить до минимальной информации.

--- a/src/modules/CountryPage/components/CountryPageView/components/PhotoGallery/PhotoGallery.tsx
+++ b/src/modules/CountryPage/components/CountryPageView/components/PhotoGallery/PhotoGallery.tsx
@@ -11,15 +11,9 @@ import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
 import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 
 import {
-  CountryType,
   LanguagesType,
   SliderDataType,
-  State,
-  UserInfo,
 } from 'types';
-import { Button } from '@material-ui/core';
-import { useSelector } from 'react-redux';
-import { database } from 'services';
 import classes from './PhotoGallery.module.scss';
 
 type PhotoGalleryProps = {
@@ -136,30 +130,6 @@ export const PhotoGallery: FC<PhotoGalleryProps> = ({ sliderData, lang }) => {
     }
   };
 
-  const userId = useSelector((state: State) => state.userInfo.id);
-  const countryId = useSelector((state: State) => state.country.id);
-
-  const setRating = (attrId: string, rating: number) => {
-    database
-      .setRating(countryId, attrId, userId, rating)
-      .then((data: [UserInfo, CountryType]) => {
-        // в ответе получаем данные пользователя и данные текущей страны.
-        // Возможно это излишняя инфа и я попробую ее сократить до минимальной информации.
-        // в любом случае, там можно увидеть измененные рейтинги у пльзователя и у страны
-        // мы можем показывать пользователю не только общую ойценку, но и как он оценил
-        // в стране храниться сумма и количество голосовавших. Среднее нужно вычислять
-        // У пользователя храниться его оценка просто.
-        // Подробней насчет типов описано в типах
-
-        const [user, country] = data;
-        console.log(
-          'User rating',
-          user.attractionRates.find((value) => value.attrId === attrId)
-        );
-        console.log('country', country);
-      });
-  };
-
   useEffect(() => {
     document.onfullscreenchange = () => {
       setFullScreen(document.fullscreenElement === sliderRef.current);
@@ -183,24 +153,6 @@ export const PhotoGallery: FC<PhotoGalleryProps> = ({ sliderData, lang }) => {
             <p className={classes.slickImageDescription}>
               {slide.description[lang as keyof LanguagesType]}
             </p>
-            <p style={{ fontSize: '20px', color: 'red' }}>
-              Рейтинг сумма: {slide.rating.sum}, количество,{' '}
-              {slide.rating.count}
-            </p>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={() => setRating(slide.id, 5)}
-            >
-              Рейтинг 5
-            </Button>
-            <Button
-              variant="contained"
-              color="secondary"
-              onClick={() => setRating(slide.id, 1)}
-            >
-              Рейтинг 1
-            </Button>
           </div>
         </div>
       ))

--- a/src/modules/CountryPage/components/CountryPageView/components/PhotoGallery/PhotoGallery.tsx
+++ b/src/modules/CountryPage/components/CountryPageView/components/PhotoGallery/PhotoGallery.tsx
@@ -10,8 +10,18 @@ import FullscreenExitIcon from '@material-ui/icons/FullscreenExit';
 import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
 import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 
-import { LanguagesType, SliderDataType } from 'types';
+import {
+  CountryType,
+  LanguagesType,
+  SliderDataType,
+  State,
+  UserInfo,
+} from 'types';
+import { Button } from '@material-ui/core';
+import { useSelector } from 'react-redux';
+import { database } from 'services';
 import classes from './PhotoGallery.module.scss';
+import { log } from 'util';
 
 type PhotoGalleryProps = {
   sliderData: SliderDataType[];
@@ -127,6 +137,30 @@ export const PhotoGallery: FC<PhotoGalleryProps> = ({ sliderData, lang }) => {
     }
   };
 
+  const userId = useSelector((state: State) => state.userInfo.id);
+  const countryId = useSelector((state: State) => state.country.id);
+
+  const setRating = (attrId: string, rating: number) => {
+    database
+      .setRaiting(countryId, attrId, userId, rating)
+      .then((data: [UserInfo, CountryType]) => {
+        // в ответе получаем данные пользователя и данные текущей страны.
+        // Возможно это излишняя инфа и я попробую ее сократить до минимальной информации.
+        // в любом случае, там можно увидеть измененные рейтинги у пльзователя и у страны
+        // мы можем показывать пользователю не только общую ойценку, но и как он оценил
+        // в стране храниться сумма и количество голосовавших. Среднее нужно вычислять
+        // У пользователя храниться его оценка просто.
+        // Подробней насчет типов описано в типах
+
+        const [user, country] = data;
+        console.log(
+          'User rating',
+          user.attractionRates.find((value) => value.attrId === attrId)
+        );
+        console.log('country', country);
+      });
+  };
+
   useEffect(() => {
     document.onfullscreenchange = () => {
       setFullScreen(document.fullscreenElement === sliderRef.current);
@@ -138,7 +172,7 @@ export const PhotoGallery: FC<PhotoGalleryProps> = ({ sliderData, lang }) => {
 
   const slides = sliderData
     ? sliderData.map((slide) => (
-        <div className={classes.slickImage} key={slide.photo}>
+        <div className={classes.slickImage} key={slide.id}>
           <img
             src={slide.photo}
             alt={slide.name[lang as keyof LanguagesType]}
@@ -150,6 +184,24 @@ export const PhotoGallery: FC<PhotoGalleryProps> = ({ sliderData, lang }) => {
             <p className={classes.slickImageDescription}>
               {slide.description[lang as keyof LanguagesType]}
             </p>
+            <p style={{ fontSize: '20px', color: 'red' }}>
+              Рейтинг сумма: {slide.rating.sum}, количество,{' '}
+              {slide.rating.count}
+            </p>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={() => setRating(slide.id, 5)}
+            >
+              Рейтинг 5
+            </Button>
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={() => setRating(slide.id, 1)}
+            >
+              Рейтинг 1
+            </Button>
           </div>
         </div>
       ))

--- a/src/services/mongodb.ts
+++ b/src/services/mongodb.ts
@@ -1,4 +1,4 @@
-import { CurrencyType, CountryType, DBUser, GeoType } from 'types';
+import { CountryType, CurrencyType, DBUser, GeoType, UserInfo } from 'types';
 import { COUNTRY_PER_PAGE } from 'appConstants';
 
 class MongoDatabase {
@@ -34,6 +34,28 @@ class MongoDatabase {
 
   getGeo = async (): Promise<[GeoType]> =>
     fetch(`${this.URL}/geo`).then((data) => data.json());
+
+  setRaiting = async (
+    countryId: string,
+    attractionId: string,
+    userId: string,
+    rating: number
+  ): Promise<[UserInfo, CountryType]> => {
+    const url = `${this.URL}/country/${countryId}/attraction`;
+    const data = {
+      attractionId,
+      userId,
+      rating,
+    };
+
+    return fetch(url, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }).then((res) => res.json());
+  };
 }
 
 export const database = MongoDatabase.create();

--- a/src/services/mongodb.ts
+++ b/src/services/mongodb.ts
@@ -1,11 +1,16 @@
-import { CountryType, CurrencyType, DBUser, GeoType, UserInfo } from 'types';
+import {
+  CountryType,
+  CurrencyType,
+  DBUser,
+  GeoType,
+  RatingServerResponse,
+} from 'types';
 import { COUNTRY_PER_PAGE } from 'appConstants';
 
 class MongoDatabase {
   private readonly URL: string;
 
   constructor() {
-    // this.URL = 'http://localhost:3001'; // local url for tests
     this.URL = 'https://malagor-travel-app-47934.herokuapp.com';
   }
 
@@ -40,7 +45,7 @@ class MongoDatabase {
     attractionId: string,
     userId: string,
     rating: number
-  ): Promise<[UserInfo, CountryType]> => {
+  ): Promise<RatingServerResponse> => {
     const url = `${this.URL}/country/${countryId}/attraction`;
     const data = {
       attractionId,

--- a/src/services/mongodb.ts
+++ b/src/services/mongodb.ts
@@ -35,7 +35,7 @@ class MongoDatabase {
   getGeo = async (): Promise<[GeoType]> =>
     fetch(`${this.URL}/geo`).then((data) => data.json());
 
-  setRaiting = async (
+  setRating = async (
     countryId: string,
     attractionId: string,
     userId: string,

--- a/src/store/initialState.ts
+++ b/src/store/initialState.ts
@@ -10,6 +10,7 @@ export const initialState = () => {
       lang: 'ru',
       theme: 'light',
       currencies: ['USD', 'EUR', 'BYN'],
+      attractionRates: []
     },
     country: {
       id: '',

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export type UserInfo = {
   lang: string;
   theme: string;
   currencies: string[];
+  attractionRates: { attrId: string; rating: number }[];
 };
 
 export type LanguagesType = {
@@ -72,6 +73,10 @@ export type SliderDataType = {
   photo: string;
   name: LanguagesType;
   description: LanguagesType;
+  rating: {
+    sum: number;
+    count: number;
+  };
 };
 
 export type CountryType = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export type LanguagesType = {
 };
 
 export type SliderDataType = {
+  id: string;
   photo: string;
   name: LanguagesType;
   description: LanguagesType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,3 +136,14 @@ export type GeoType = {
     coordinates: [[GeoPointType[]]];
   };
 };
+
+export type RatingServerResponse = {
+  attrId: string;
+  countryId: string;
+  userId: string;
+  userRating: number;
+  attrRating: {
+    sum: number;
+    count: number;
+  };
+};


### PR DESCRIPTION
Closes: #61 
Добавил метод установки рейтинга

Для изменения (установки) рейтинга используется функция database.setRating
для использования функции нужно импортировать `import {database} from "services"`

```
database.setRating = async (
    countryId: string,
    attractionId: string,
    userId: string,
    rating: number
  )
```
В базу данных добавил поле idю Его же разумней использовать в качестве ключа при маппинге элементов.

Функция возвращает объект:
```
type RatingServerResponse = {
  attrId: string;
  countryId: string;
  userId: string;
  userRating: number;
  attrRating: {
    sum: number;
    count: number;
  };
};
```