### PR TITLE
TA-47  fix map bounds setting

### DIFF
--- a/src/modules/CountryPage/components/CountryPageView/components/Map/Map.tsx
+++ b/src/modules/CountryPage/components/CountryPageView/components/Map/Map.tsx
@@ -65,12 +65,15 @@ export const Map: FC<MapProps> = ({ geo, capital }) => {
   }, [mapElement, manager]);
 
   useEffect(() => {
-    if (mapElement && countryPolygon) {
-      mapElement.setBounds(countryPolygon.geometry.getBounds(), {
-        checkZoomRange: true,
-      });
+    if (ymaps && mapElement && countryPolygon) {
+      const bounds = mapElement.geoObjects.getBounds();
+      if (bounds) {
+        mapElement.setBounds(bounds, {
+          checkZoomRange: true,
+        });
+      }
     }
-  }, [mapElement, countryPolygon, capital]);
+  }, [ymaps, mapElement, countryPolygon, capital]);
 
   useEffect(() => {
     if (ymaps && mapElement) {


### PR DESCRIPTION
Closes: #102 
Исправила приближения карты к стране, до этого карта брала последний добавленный полигон из-за чего в зум не всегда помещалась вся страна.

Было:
![image](https://user-images.githubusercontent.com/64521658/111723224-e0d70c00-886b-11eb-8e13-6e49d786b02e.png)

Стало:
![image](https://user-images.githubusercontent.com/64521658/111723130-be44f300-886b-11eb-8623-200568013b6a.png)

