### PR TITLE
TA-48 fix currency widget on mobile

### DIFF
--- a/src/components/CurrencyRate/CurrencyRate.module.scss
+++ b/src/components/CurrencyRate/CurrencyRate.module.scss
@@ -7,4 +7,6 @@
   padding: 10px 30px;
   min-width: 150px;
   min-height: 150px;
+  flex-shrink: 0;
+  margin-bottom: 20px;
 }


### PR DESCRIPTION
Closes: #104 
Исправила поведение виджета валют на мобильных устройствах. Проблема была в том что там везде установлен дисплей флекс, а высоты самого экрана не хватает, поэтому элемент сжимался до минимальной высоты если она была задана.

![image](https://user-images.githubusercontent.com/64521658/111730270-b8560e80-8879-11eb-9d25-41e0c0a18d1a.png)
